### PR TITLE
Changing installation check behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .idea/
 /upload/
 /system/modification/
+/config.php

--- a/admin/define.php
+++ b/admin/define.php
@@ -43,17 +43,3 @@ define('DIR_LOGS', 			DIR_SYSTEM . 'log/'); // depreciated due to plural usage, 
 define('DIR_MODIFICATION',	DIR_SYSTEM . 'modification/');
 define('DIR_LANGUAGE',		DIR_APPLICATION . 'language/');
 define('DIR_TEMPLATE', 		DIR_APPLICATION . 'view/template/');
-
-// Installation check, and check on removal of the install directory.
-if (!file_exists(DIR_ROOT . 'config.php') or (filesize(DIR_ROOT . 'config.php') < 10) or file_exists(DIR_INSTALL . 'index.php')) {
-    if (file_exists(DIR_INSTALL . 'index.php')) {
-        header('Location: ../install/index.php');
-
-        exit();
-    }
-    else {
-        echo 'No configuration file found and no installation code available. Exiting...';
-
-        exit();
-    }
-}

--- a/define.php
+++ b/define.php
@@ -40,17 +40,3 @@ define('DIR_LOG', 			DIR_SYSTEM . 'log/');
 define('DIR_LOGS', 			DIR_SYSTEM . 'log/'); // depreciated due to plural usage, use DIR_LOG
 define('DIR_LANGUAGE', 		DIR_APPLICATION . 'language/');
 define('DIR_TEMPLATE', 		DIR_APPLICATION . 'view/theme/');
-
-// Installation check, and check on removal of the install directory.
-if (!file_exists(DIR_ROOT . 'config.php') or (filesize(DIR_ROOT . 'config.php') < 10) or file_exists(DIR_INSTALL . 'index.php')) {
-    if (file_exists(DIR_INSTALL . 'index.php')) {
-		header('Location: ' . substr($_SERVER['REQUEST_URI'], 0, strpos($_SERVER['REQUEST_URI'], 'index.php')) . 'install/index.php');
-		
-        exit();
-    }
-    else {
-        echo 'No configuration file found and no installation code available. Exiting...';
-
-        exit();
-    }
-}

--- a/install/index.php
+++ b/install/index.php
@@ -13,6 +13,7 @@ if (version_compare(PHP_VERSION, '5.3.10', '<')) {
 }
 
 define('AREXE', 1);
+define('INSTALLER', 1);
 
 require_once('define.php');
 

--- a/system/startup.php
+++ b/system/startup.php
@@ -5,12 +5,23 @@
  * @license		GNU General Public License version 3; see LICENSE.txt
  */
 
+// Installation check, and check on removal of the install directory.
+if ((!file_exists(DIR_ROOT . 'config.php') || (filesize(DIR_ROOT . 'config.php') < 10)) && !defined('INSTALLER')) {
+	if (file_exists(DIR_INSTALL . 'index.php')) {
+		header('Location: ' . str_replace(array('admin', 'index.php', '//'), array('', '', '/'), $_SERVER['REQUEST_URI']) . 'install/index.php');
+
+		exit();
+	} else {
+		die('No configuration file found and no installation code available. Exiting...');
+	}
+}
+
 // Error Reporting
 error_reporting(E_ALL);
 
 // Check Version
 if (version_compare(PHP_VERSION, '5.3.10', '<')) {
-    die('Your host needs to use PHP 5.3.10 or higher to run Arastta.');
+	die('Your host needs to use PHP 5.3.10 or higher to run Arastta.');
 }
 
 if (!ini_get('date.timezone')) {
@@ -53,7 +64,7 @@ if (isset($_SERVER['HTTPS']) && (($_SERVER['HTTPS'] == 'on') || ($_SERVER['HTTPS
 
 // Composer
 if (!file_exists(DIR_SYSTEM.'vendor/autoload.php')) {
-    die('You need to run Composer first. More details https://github.com/arastta/arastta');
+	die('You need to run Composer first. More details https://github.com/arastta/arastta');
 }
 require_once(DIR_SYSTEM.'vendor/autoload.php');
 
@@ -68,11 +79,11 @@ function modification($filename) {
 	if (substr($filename, 0, strlen(DIR_SYSTEM)) == DIR_SYSTEM) {
 		$file = DIR_MODIFICATION . 'system/' . substr($filename, strlen(DIR_SYSTEM));
 	}
-	
+
 	if (is_file($file)) {
 		return $file;
 	}
-	
+
 	return $filename;
 }
 
@@ -85,13 +96,12 @@ function autoload($class) {
 		include(modification($lib));
 
 		return true;
-	}
-    else if (is_file($app)) {
+	} else if (is_file($app)) {
 		include(modification($app));
 
 		return true;
 	}
-    
+
 	return false;
 }
 


### PR DESCRIPTION
Changes:
1. Added config.php to .gitignore
2. Moved the install check to startup.php (makes more sense in there than define.php).
3. The installer will not run if the config.php file exists. Previously it still would if the install folder existed. The main reason for this change is version control (it's annoying having the removed install folder showing up in the git changes).
3. Fixed coding standards (indentation, newlines)
