### PR TITLE
Category search fix

### DIFF
--- a/admin/model/search/search.php
+++ b/admin/model/search/search.php
@@ -26,17 +26,17 @@ class ModelSearchSearch extends Model {
     }
 
     public function getCategories($data = array()) {
-        $sql = "SELECT cp.category_id AS category_id, GROUP_CONCAT(cd1.name ORDER BY cp.level SEPARATOR '&nbsp;&nbsp;&gt;&nbsp;&nbsp;') AS name, c1.image
+        $sql = "SELECT cp.category_id AS category_id, GROUP_CONCAT(cdpath.name ORDER BY cp.level SEPARATOR '&nbsp;&nbsp;&gt;&nbsp;&nbsp;') AS name, cmain.image
                 FROM " . DB_PREFIX . "category_path cp
-                LEFT JOIN " . DB_PREFIX . "category c1 ON (cp.category_id = c1.category_id)
-                LEFT JOIN " . DB_PREFIX . "category c2 ON (cp.path_id = c2.category_id)
-                LEFT JOIN " . DB_PREFIX . "category_description cd1 ON (cp.path_id = cd1.category_id)
-                LEFT JOIN " . DB_PREFIX . "category_description cd2 ON (cp.category_id = cd2.category_id)
-                WHERE cd1.language_id = '" . (int)$this->config->get('config_language_id') . "'
-                    AND cd2.language_id = '" . (int)$this->config->get('config_language_id') . "'
-                    AND cd1.name LIKE '" . $this->db->escape($data['query']) . "%'
+                LEFT JOIN " . DB_PREFIX . "category cmain ON (cp.category_id = cmain.category_id)
+                LEFT JOIN " . DB_PREFIX . "category cpath ON (cp.path_id = cpath.category_id)
+                LEFT JOIN " . DB_PREFIX . "category_description cdmain ON (cp.category_id = cdmain.category_id)
+                LEFT JOIN " . DB_PREFIX . "category_description cdpath ON (cp.path_id = cdpath.category_id)
+                WHERE cdpath.language_id = '" . (int)$this->config->get('config_language_id') . "'
+                    AND cdmain.language_id = '" . (int)$this->config->get('config_language_id') . "'
+                    AND cdmain.name LIKE '%" . $this->db->escape($data['query']) . "%'
                 GROUP BY cp.category_id
-                ORDER BY cd1.name ASC
+                ORDER BY name ASC
                 LIMIT 5";
 
         $query = $this->db->query($sql);


### PR DESCRIPTION
Previously, searching for a category e.g. 'Laptop' would return all categories that had 'Laptop' as its parent' but only show the parent name, so there would be 3 entries called 'Laptop'.

What I have done here is renamed the SQL vars to avoid confusion (c1 -> cmain, c2 -> cpath etc), and also changed the following functionality:
1. Search looks for the query string in a path's main category name (as opposed to one of the path item names)
2. Search will find results that have the query string anywhere in the category name (changed "LIKE 'query%' " to "LIKE '%query%' ")
3. Order results by entire category name (including parent categories)
