### PR TITLE
Allow event listeners to modify variables passed by reference

### DIFF
--- a/system/library/trigger.php
+++ b/system/library/trigger.php
@@ -46,7 +46,7 @@ class Trigger extends Object {
 
         foreach ($this->listeners[$event] as $listener) {
             if (is_callable(array($listener, $method))) {
-                $value = call_user_func(array($listener, $method), $arg);
+                $value = call_user_func_array(array($listener, $method), array(&$arg));
             }
 
             if (!empty($value)) {


### PR DESCRIPTION
Ensure event listener functions can modify the variables that are passed by reference and have those modifications be reflected in the same scope as the event caller/trigger.

Relevant information at http://php.net/manual/en/function.call-user-func.php under 'parameter' note.
