### PR TITLE
Check for existing SEO URLs

### DIFF
--- a/admin/model/catalog/category.php
+++ b/admin/model/catalog/category.php
@@ -100,7 +100,7 @@ class ModelCatalogCategory extends Model {
         foreach ($data['seo_url'] as $language_id => $value) {
             $alias = empty($value) ? $data['category_description'][$language_id]['name'] : $value;
 
-            $alias = $this->model_catalog_url_alias->generateAlias($alias);
+            $alias = $this->model_catalog_url_alias->generateAlias($alias, $category_id);
 
             if ($alias) {
                 $this->db->query("INSERT INTO " . DB_PREFIX . "url_alias SET query = 'category_id=" . (int)$category_id . "', keyword = '" . $this->db->escape($alias) . "', language_id = '" . $language_id . "'");
@@ -334,7 +334,7 @@ class ModelCatalogCategory extends Model {
 
             $alias = empty($value) ? $data['category_description'][$language_id]['name'] : $value;
 
-            $alias = $this->model_catalog_url_alias->generateAlias($alias);
+            $alias = $this->model_catalog_url_alias->generateAlias($alias, $category_id);
 
             if ($alias) {
                 $this->db->query("INSERT INTO " . DB_PREFIX . "url_alias SET query = 'category_id=" . (int)$category_id . "', keyword = '" . $this->db->escape($alias) . "', language_id = '" . $language_id . "'");

--- a/admin/model/catalog/information.php
+++ b/admin/model/catalog/information.php
@@ -35,7 +35,7 @@ class ModelCatalogInformation extends Model {
         foreach ($data['seo_url'] as $language_id => $value) {
             $alias = empty($value) ? $data['information_description'][$language_id]['title'] : $value;
 
-            $alias = $this->model_catalog_url_alias->generateAlias($alias);
+            $alias = $this->model_catalog_url_alias->generateAlias($alias, $information_id);
 
             if ($alias) {
                 $this->db->query("INSERT INTO " . DB_PREFIX . "url_alias SET query = 'information_id=" . (int)$information_id . "', keyword = '" . $this->db->escape($alias) . "', language_id = '" . $language_id . "'");
@@ -83,7 +83,7 @@ class ModelCatalogInformation extends Model {
 
             $alias = empty($value) ? $data['information_description'][$language_id]['title'] : $value;
 
-            $alias = $this->model_catalog_url_alias->generateAlias($alias);
+            $alias = $this->model_catalog_url_alias->generateAlias($alias, $information_id);
 
             if ($alias) {
                 $this->db->query("INSERT INTO " . DB_PREFIX . "url_alias SET query = 'information_id=" . (int)$information_id . "', keyword = '" . $this->db->escape($alias) . "', language_id = '" . $language_id . "'");

--- a/admin/model/catalog/manufacturer.php
+++ b/admin/model/catalog/manufacturer.php
@@ -41,7 +41,7 @@ class ModelCatalogManufacturer extends Model {
         foreach ($data['seo_url'] as $language_id => $value) {
             $alias = empty($value) ? $data['manufacturer_description'][$language_id]['name'] : $value;
 
-            $alias = $this->model_catalog_url_alias->generateAlias($alias);
+            $alias = $this->model_catalog_url_alias->generateAlias($alias, $manufacturer_id);
 
             if ($alias) {
                 $this->db->query("INSERT INTO " . DB_PREFIX . "url_alias SET query = 'manufacturer_id=" . (int)$manufacturer_id . "', keyword = '" . $this->db->escape($alias) . "', language_id = '" . $language_id . "'");
@@ -93,7 +93,7 @@ class ModelCatalogManufacturer extends Model {
 
             $alias = empty($value) ? $data['manufacturer_description'][$language_id]['name'] : $value;
 
-            $alias = $this->model_catalog_url_alias->generateAlias($alias);
+            $alias = $this->model_catalog_url_alias->generateAlias($alias, $manufacturer_id);
 
             if ($alias) {
                 $this->db->query("INSERT INTO " . DB_PREFIX . "url_alias SET query = 'manufacturer_id=" . (int)$manufacturer_id . "', keyword = '" . $this->db->escape($alias) . "', language_id = '" . $language_id . "'");

--- a/admin/model/catalog/product.php
+++ b/admin/model/catalog/product.php
@@ -122,7 +122,7 @@ class ModelCatalogProduct extends Model {
             foreach ($data['seo_url'] as $language_id => $value) {
                 $alias = empty($value) ? $data['product_description'][$language_id]['name'] : $value;
 
-                $alias = $this->model_catalog_url_alias->generateAlias($alias);
+                $alias = $this->model_catalog_url_alias->generateAlias($alias, $product_id);
 
                 if ($alias) {
                     $this->db->query("INSERT INTO " . DB_PREFIX . "url_alias SET query = 'product_id=" . (int)$product_id . "', keyword = '" . $this->db->escape($alias) . "', language_id = '" . $language_id . "'");
@@ -285,7 +285,7 @@ class ModelCatalogProduct extends Model {
 
             $alias = empty($value) ? $data['product_description'][$language_id]['name'] : $value;
 
-            $alias = $this->model_catalog_url_alias->generateAlias($alias);
+            $alias = $this->model_catalog_url_alias->generateAlias($alias, $product_id);
 
             if ($alias) {
                 $this->db->query("INSERT INTO " . DB_PREFIX . "url_alias SET query = 'product_id=" . (int)$product_id . "', keyword = '" . $this->db->escape($alias) . "', language_id = '" . $language_id . "'");

--- a/admin/model/catalog/url_alias.php
+++ b/admin/model/catalog/url_alias.php
@@ -14,10 +14,25 @@ class ModelCatalogUrlAlias extends Model {
 		return $query->row;
 	}
 
-    public function generateAlias($title) {
+    public function generateAlias($title, $id = null) {
         $title = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
 
         $alias = $this->safeAlias($title);
+
+        if ($id) {
+            $count = 0;
+            $baseAlias = $alias;
+
+            while ($this->db->query("SELECT COUNT(*) AS count FROM " . DB_PREFIX . "url_alias WHERE keyword = '" . $this->db->escape($alias) . "'")->row['count'] > 0) {
+                if ($count == 0) {
+                    $baseAlias = ($alias = $alias . '-' . $id) . '-';
+                } else {
+                    $alias = $baseAlias . $count;
+                }
+
+                $count++;
+            }
+        }
 
         return $alias;
     }


### PR DESCRIPTION
See issue #118 

Reason for the while loop is to increment a second appended number in the rare case that there are items with the same id (e.g. a product and a category with the same id) that have conflicting SEO URLs. In such a case the SEO keyword would look like "categoryname-63-1"
