### PR TITLE
Professional texts at checkout instead of plain 'continue'

### DIFF
--- a/catalog/controller/payment/bank_transfer.php
+++ b/catalog/controller/payment/bank_transfer.php
@@ -10,9 +10,11 @@ class ControllerPaymentBankTransfer extends Controller {
 	public function index() {
 		$this->load->language('payment/bank_transfer');
 
-		$data['text_instruction'] = $this->language->get('text_instruction');
-		$data['text_description'] = $this->language->get('text_description');
-		$data['text_payment'] = $this->language->get('text_payment');
+		$data['text_instruction']		= $this->language->get('text_instruction');
+		$data['text_description']		= $this->language->get('text_description');
+		$data['text_payment']			= $this->language->get('text_payment');
+		$data['text_order_processing']	= $this->language->get('text_order_processing');
+		$data['text_order_complete']	= $this->language->get('text_order_complete');
 
 		$data['button_confirm'] = $this->language->get('button_confirm');
 

--- a/catalog/controller/payment/cod.php
+++ b/catalog/controller/payment/cod.php
@@ -8,7 +8,9 @@
 
 class ControllerPaymentCod extends Controller {
 	public function index() {
-		$data['button_confirm'] = $this->language->get('button_confirm');
+		$data['button_confirm']			= $this->language->get('button_confirm');
+		$data['text_order_processing']	= $this->language->get('text_order_processing');
+		$data['text_order_complete']	= $this->language->get('text_order_complete');
 
 		$data['continue'] = $this->url->link('checkout/success');
 

--- a/catalog/controller/payment/free_checkout.php
+++ b/catalog/controller/payment/free_checkout.php
@@ -8,7 +8,9 @@
 
 class ControllerPaymentFreeCheckout extends Controller {
 	public function index() {
-		$data['button_confirm'] = $this->language->get('button_confirm');
+		$data['button_confirm']			= $this->language->get('button_confirm');
+		$data['text_order_processing']	= $this->language->get('text_order_processing');
+		$data['text_order_complete']	= $this->language->get('text_order_complete');
 
 		$data['continue'] = $this->url->link('checkout/success');
 

--- a/catalog/language/en-GB/default.php
+++ b/catalog/language/en-GB/default.php
@@ -25,6 +25,8 @@ $_['text_select']           = ' --- Please Select --- ';
 $_['text_all_zones']        = 'All Zones';
 $_['text_pagination']       = 'Showing %d to %d of %d (%d Pages)';
 $_['text_loading']          = 'Loading...';
+$_['text_order_processing']	= 'Please be patient .. processing your order ..';
+$_['text_order_complete']	= 'Thank you for the order.';
 
 // Buttons
 $_['button_address_add']    = 'Add Address';

--- a/catalog/view/theme/default/template/payment/bank_transfer.tpl
+++ b/catalog/view/theme/default/template/payment/bank_transfer.tpl
@@ -6,7 +6,7 @@
 </div>
 <div class="buttons">
   <div class="pull-right">
-    <input type="button" value="<?php echo $button_confirm; ?>" id="button-confirm" class="btn btn-primary" />
+    <input type="button" value="<?php echo $button_confirm; ?>" data-loading-text="<?php echo $text_order_processing; ?>" data-reset-text="<?php echo $text_order_complete; ?>" id="button-confirm" class="btn btn-primary" />
   </div>
 </div>
 <script type="text/javascript"><!--
@@ -28,4 +28,4 @@ $('#button-confirm').on('click', function() {
 		}		
 	});
 });
-//--></script> 
+//--></script>

--- a/catalog/view/theme/default/template/payment/cod.tpl
+++ b/catalog/view/theme/default/template/payment/cod.tpl
@@ -1,6 +1,6 @@
 <div class="buttons">
   <div class="pull-right">
-    <input type="button" value="<?php echo $button_confirm; ?>" id="button-confirm" class="btn btn-primary" />
+    <input type="button" value="<?php echo $button_confirm; ?>" data-loading-text="<?php echo $text_order_processing; ?>" data-reset-text="<?php echo $text_order_complete; ?>" id="button-confirm" class="btn btn-primary" />
   </div>
 </div>
 <script type="text/javascript"><!--
@@ -22,4 +22,4 @@ $('#button-confirm').on('click', function() {
 		}		
 	});
 });
-//--></script> 
+//--></script>

--- a/catalog/view/theme/default/template/payment/free_checkout.tpl
+++ b/catalog/view/theme/default/template/payment/free_checkout.tpl
@@ -1,6 +1,6 @@
 <div class="buttons">
   <div class="pull-right">
-    <input type="button" value="<?php echo $button_confirm; ?>" id="button-confirm" class="btn btn-primary" />
+    <input type="button" value="<?php echo $button_confirm; ?>" data-loading-text="<?php echo $text_order_processing; ?>" data-reset-text="<?php echo $text_order_complete; ?>" id="button-confirm" class="btn btn-primary" />
   </div>
 </div>
 <script type="text/javascript"><!--
@@ -22,4 +22,4 @@ $('#button-confirm').on('click', function() {
 		}		
 	});
 });
-//--></script> 
+//--></script>


### PR DESCRIPTION
Added 2 language vars to the default.php and inside the payment controllers and templates.
Removed emtpy lines and spaces.
