### PR TITLE
Fixing wrong language linking

### DIFF
--- a/admin/controller/common/header.php
+++ b/admin/controller/common/header.php
@@ -221,7 +221,7 @@ class ControllerCommonHeader extends Controller {
 			'br' => 'pt-br',
 			'zh' => 'zh-cn',
 			'tw' => 'zh-tw',
-			'no' => 'nn'
+			'no' => 'nb'
 		);
 
         $data['moment_lang'] = $data['lang'];


### PR DESCRIPTION
no is not same as nn
no / nb = Norwegian / Norwegian Bokmål (is actually same)
nn = Norwegian Nynorsk
So this should be 'no' => 'nb'
