### PR TITLE
Add fill option to image resizer

### DIFF
--- a/catalog/model/tool/image.php
+++ b/catalog/model/tool/image.php
@@ -7,7 +7,7 @@
  */
 
 class ModelToolImage extends Model {
-	public function resize($filename, $width, $height) {
+	public function resize($filename, $width, $height, $fill = false) {
 		if (!is_file(DIR_IMAGE . $filename)) {
 			return;
 		}
@@ -33,8 +33,14 @@ class ModelToolImage extends Model {
 			list($width_orig, $height_orig) = getimagesize(DIR_IMAGE . $old_image);
 
 			if ($width_orig != $width || $height_orig != $height) {
+				if ($fill) {
+					$dimension = $width_orig > $height_orig ? 'h' : 'w';
+				} else {
+					$dimension = '';
+				}
+
 				$image = new Image(DIR_IMAGE . $old_image);
-				$image->resize($width, $height);
+				$image->resize($width, $height, $dimension);
 				$image->save(DIR_IMAGE . $new_image);
 			} else {
 				copy(DIR_IMAGE . $old_image, DIR_IMAGE . $new_image);


### PR DESCRIPTION
A useful thing that I always add to OpenCart sites I work on. Allows for a developer to resize an image and have it fill the specified dimensions rather than fit inside it (so no whitespace on the image).

PS: It's BrettMW. I changed my GitHub username :smile: 
