### PR TITLE
Relative image URL

### DIFF
--- a/admin/controller/common/filemanager.php
+++ b/admin/controller/common/filemanager.php
@@ -78,19 +78,12 @@ class ControllerCommonFileManager extends Controller {
                     'href'  => $this->url->link('common/filemanager', 'token=' . $this->session->data['token'] . '&directory=' . urlencode(utf8_substr($image, utf8_strlen(DIR_IMAGE . 'catalog/'))) . $url, 'SSL')
                 );
             } elseif (is_file($image)) {
-                // Find which protocol to use to pass the full image link back
-                if ($this->request->server['HTTPS']) {
-                    $server = HTTPS_CATALOG;
-                } else {
-                    $server = HTTP_CATALOG;
-                }
-
                 $data['images'][] = array(
                     'thumb' => $this->model_tool_image->resize(utf8_substr($image, utf8_strlen(DIR_IMAGE)), 100, 100),
                     'name'  => implode(' ', $name),
                     'type'  => 'image',
                     'path'  => utf8_substr($image, utf8_strlen(DIR_IMAGE)),
-                    'href'  => $server . 'image/' . utf8_substr($image, utf8_strlen(DIR_IMAGE))
+                    'href'  => '/image/' . utf8_substr($image, utf8_strlen(DIR_IMAGE))
                 );
             }
         }

--- a/admin/controller/common/filemanager.php
+++ b/admin/controller/common/filemanager.php
@@ -78,6 +78,13 @@ class ControllerCommonFileManager extends Controller {
                     'href'  => $this->url->link('common/filemanager', 'token=' . $this->session->data['token'] . '&directory=' . urlencode(utf8_substr($image, utf8_strlen(DIR_IMAGE . 'catalog/'))) . $url, 'SSL')
                 );
             } elseif (is_file($image)) {
+                // Find which protocol to use to pass the full image link back
+                if ($this->request->server['HTTPS']) {
+                    $server = HTTPS_CATALOG;
+                } else {
+                    $server = HTTP_CATALOG;
+                }
+
                 $data['images'][] = array(
                     'thumb' => $this->model_tool_image->resize(utf8_substr($image, utf8_strlen(DIR_IMAGE)), 100, 100),
                     'name'  => implode(' ', $name),


### PR DESCRIPTION
Arastta and its root is inserting images with full URL including http protocol and domain, into content code. T.ex. in product/category description, modules and information pages etc. This will fix it, to avoid problems for multi-domain shops, or changed domains. Or simply when going from http to https. Ref. https://arastta.org/forum/why-full-and-not-relative-image-url
