### PR TITLE
Product detail page previous and next buttons are added

### DIFF
--- a/catalog/event/product/previous_next.php
+++ b/catalog/event/product/previous_next.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @package        Arastta eCommerce
+ * @copyright      Copyright (C) 2015-2016 Arastta Association. All rights reserved. (arastta.org)
+ * @credits        See CREDITS.txt for credits and other copyright notices.
+ * @license        GNU General Public License version 3; see LICENSE.txt
+ */
+
+class EventProductPreviousNext extends Event
+{
+    public function preProductDisplay(&$data, $type)
+    {
+        if (isset($this->request->get['product_id'])) {
+            $product_id = (int)$this->request->get['product_id'];
+        } else {
+            $product_id = 0;
+        }
+
+        if ($type != 'product' || !$product_id) {
+            return;
+        }
+
+        $product_info = $this->model_catalog_product->getProduct($product_id);
+
+        if (isset($this->request->get['path'])) {
+            $parts = explode('_', (string)$this->request->get['path']);
+
+            $category_id = (int)array_pop($parts);
+        } else {
+            $categories = $this->model_catalog_product->getCategories($product_id);
+
+            if (!$categories) {
+                return;
+            }
+
+            $category_id = (int)array_shift($categories)['category_id'];
+        }
+
+        $filter_data = array(
+            'filter_category_id' => $category_id,
+            'sort'               => 'pd.name',
+            'order'              => 'ASC',
+            'start'              => 0,
+            'limit'              => 1000
+        );
+
+        $results = $this->model_catalog_product->getProducts($filter_data);
+
+        $product = false;
+
+        $previous_product = $next_product = null;
+
+        foreach ($results as $result) {
+            if ($result['name'] == $product_info['name']) {
+                $product = true;
+            } elseif (!$product) {
+                $previous_product = $result;
+            } else {
+                $next_product = $result;
+                break;
+            }
+        }
+
+        $data['next'] = array();
+        $data['previous'] = array();
+
+        if ($next_product) {
+            $data['next'] = array(
+                'name'  => $next_product['name'],
+                'image' => $this->model_tool_image->resize($next_product['image'], $this->config->get('config_image_thumb_width'), $this->config->get('config_image_thumb_height')),
+                'price' => ($this->config->get('config_customer_price') && $this->customer->isLogged()) || !$this->config->get('config_customer_price') ? $this->currency->format($this->tax->calculate($next_product['price'], $next_product['tax_class_id'], $this->config->get('config_tax'))) : false,
+                'href'  => $this->url->link('product/product', 'product_id=' .  $next_product['product_id'])
+            );
+        }
+
+        if ($previous_product) {
+            $data['previous'] = array(
+                'name'  => $previous_product['name'],
+                'image' => $this->model_tool_image->resize($previous_product['image'], $this->config->get('config_image_thumb_width'), $this->config->get('config_image_thumb_height')),
+                'price' => ($this->config->get('config_customer_price') && $this->customer->isLogged()) || !$this->config->get('config_customer_price') ? $this->currency->format($this->tax->calculate($previous_product['price'], $previous_product['tax_class_id'], $this->config->get('config_tax'))) : false,
+                'href'  => $this->url->link('product/product', 'product_id=' . $previous_product['product_id'])
+            );
+        }
+    }
+}

--- a/catalog/view/theme/default/stylesheet/stylesheet.css
+++ b/catalog/view/theme/default/stylesheet/stylesheet.css
@@ -467,6 +467,21 @@ footer h5 {
     -o-transform: rotate(-45deg);
     transform: rotate(-45deg);
 }
+.breadcrumb .product-navigation {
+    margin-top: -8px;
+}
+.breadcrumb .product-navigation .btn {
+    border: none;
+    padding: 10px 12px;
+}
+.breadcrumb .product-navigation .btn-default[disabled], .breadcrumb .navigation .btn-default.disabled {
+    background: transparent;
+}
+.product-navigation-xs {
+    clear: both;
+    margin-top: -5px;
+    margin-bottom: 10px;
+}
 .pagination {
     margin: 0;
 }

--- a/catalog/view/theme/default/template/product/product.tpl
+++ b/catalog/view/theme/default/template/product/product.tpl
@@ -4,7 +4,16 @@
         <?php foreach ($breadcrumbs as $breadcrumb) { ?>
         <li><a href="<?php echo $breadcrumb['href']; ?>"><?php echo $breadcrumb['text']; ?></a></li>
         <?php } ?>
+        <div class="btn-group product-navigation pull-right hidden-xs">
+            <button type="button" data-toggle="tooltip" class="btn btn-default" onclick="window.location.href='<?php echo !empty($previous["href"]) ? $previous["href"] : ''; ?>';" title="<?php echo !empty($previous['name']) ? $previous['name'] : ''; ?>" <?php echo empty($previous["href"]) ? 'disabled' : ''; ?>><i class="fa fa-arrow-left"></i></button>
+            <button type="button" data-toggle="tooltip" class="btn btn-default" onclick="window.location.href='<?php echo !empty($next["href"]) ? $next["href"] : ''; ?>';" title="<?php echo !empty($next['name']) ? $next['name'] : ''; ?>" <?php echo empty($next["href"]) ? 'disabled' : ''; ?>><i class="fa fa-arrow-right"></i></button>
+        </div>
     </ul>
+    <div class="btn-group product-navigation-xs pull-right visible-xs">
+        <button type="button" data-toggle="tooltip" class="btn btn-default" onclick="window.location.href='<?php echo !empty($previous["href"]) ? $previous["href"] : ''; ?>';" title="<?php echo !empty($previous['name']) ? $previous['name'] : ''; ?>" <?php echo empty($previous["href"]) ? 'disabled' : ''; ?>><i class="fa fa-arrow-left"></i></button>
+        <button type="button" data-toggle="tooltip" class="btn btn-default" onclick="window.location.href='<?php echo !empty($next["href"]) ? $next["href"] : ''; ?>';" title="<?php echo !empty($next['name']) ? $next['name'] : ''; ?>" <?php echo empty($next["href"]) ? 'disabled' : ''; ?>><i class="fa fa-arrow-right"></i></button>
+    </div>
+    <div class="clearfix"></div>
     <div class="row"><?php echo $column_left; ?>
         <?php if ($column_left && $column_right) { ?>
         <?php $class = 'col-sm-6'; ?>


### PR DESCRIPTION
Product detail page previous and next buttons are added. 

**NOTE** : if 3rd party extension developers want to add product image and price in to previous and next buttons, they can edit view tpl file. Variables are already set in the controller file.

![next-previous-1](https://cloud.githubusercontent.com/assets/10936547/13919018/a64c509a-ef73-11e5-96ec-270e07dfe62d.png)

---

![next-previous-2](https://cloud.githubusercontent.com/assets/10936547/13919030/b54426ea-ef73-11e5-8d1c-092914a2b5bb.png)
