### PR TITLE
Override default add to cart on product details

### DIFF
--- a/catalog/language/en-GB/product/product.php
+++ b/catalog/language/en-GB/product/product.php
@@ -38,6 +38,9 @@ $_['text_semi_month']          = 'half-month';
 $_['text_month']               = 'month';
 $_['text_year']                = 'year';
 
+// Buttons
+$_['button_cart']              = 'Add to Cart';
+
 // Entry
 $_['entry_qty']                = 'Qty';
 $_['entry_name']               = 'Your Name';


### PR DESCRIPTION
In quite many languages and designs the full "Add to Cart" text is to long i category views etc, thus it's often shortened to "Buy" or similar in translations.

By adding this "override" in the language file for product details view, it becomes possible to use the full text here, and keeping BC for both designs and language files.

![add_to_cart_category_view](https://cloud.githubusercontent.com/assets/858132/14403657/4d3d452c-fe69-11e5-9f7e-88e6207b83cd.png)
![add_to_cart_product_details](https://cloud.githubusercontent.com/assets/858132/14403658/50efd5b8-fe69-11e5-9179-eaf00aeafadd.png)
