### PR TITLE
Suffix for rounded amounts as language strings

### DIFF
--- a/admin/controller/dashboard/customer.php
+++ b/admin/controller/dashboard/customer.php
@@ -34,18 +34,22 @@ class ControllerDashboardCustomer extends Controller {
         $customer_total = $this->model_sale_customer->getTotalCustomers();
         
         if ($customer_total > 1000000000000) {
-            $data['total'] = round($customer_total / 1000000000000, 1) . 'T';
+            $data['total'] = round($customer_total / 1000000000000, 1);
+            $suffix = $this->language->get('trillion_suffix');
         } elseif ($customer_total > 1000000000) {
-            $data['total'] = round($customer_total / 1000000000, 1) . 'B';
+            $data['total'] = round($customer_total / 1000000000, 1);
+            $suffix = $this->language->get('billion_suffix');
         } elseif ($customer_total > 1000000) {
-            $data['total'] = round($customer_total / 1000000, 1) . 'M';
+            $data['total'] = round($customer_total / 1000000, 1);
+            $suffix = $this->language->get('million_suffix');
         } elseif ($customer_total > 1000) {
-            $data['total'] = round($customer_total / 1000, 1) . 'K';                        
+            $data['total'] = round($customer_total / 1000, 1);
+            $suffix = $this->language->get('thousand_suffix');
         } else {
             $data['total'] = $customer_total;
         }
                 
-        $data['customer'] = $this->url->link('sale/customer', 'token=' . $this->session->data['token'], 'SSL');
+        $data['customer'] = $this->url->link('sale/customer', 'token=' . $this->session->data['token'], 'SSL') . $suffix;
 
         return $this->load->view('dashboard/customer.tpl', $data);
     }

--- a/admin/controller/dashboard/online.php
+++ b/admin/controller/dashboard/online.php
@@ -23,18 +23,22 @@ class ControllerDashboardOnline extends Controller {
         $online_total = $this->model_report_customer->getTotalCustomersOnline();
         
         if ($online_total > 1000000000000) {
-            $data['total'] = round($online_total / 1000000000000, 1) . 'T';
+            $data['total'] = round($online_total / 1000000000000, 1);
+            $suffix = $this->language->get('trillion_suffix');
         } elseif ($online_total > 1000000000) {
-            $data['total'] = round($online_total / 1000000000, 1) . 'B';
+            $data['total'] = round($online_total / 1000000000, 1);
+            $suffix = $this->language->get('billion_suffix');
         } elseif ($online_total > 1000000) {
-            $data['total'] = round($online_total / 1000000, 1) . 'M';
+            $data['total'] = round($online_total / 1000000, 1);
+            $suffix = $this->language->get('million_suffix');
         } elseif ($online_total > 1000) {
-            $data['total'] = round($online_total / 1000, 1) . 'K';                        
+            $data['total'] = round($online_total / 1000, 1);
+            $suffix = $this->language->get('thousand_suffix');
         } else {
             $data['total'] = $online_total;
         }            
         
-        $data['online'] = $this->url->link('report/customer_online', 'token=' . $this->session->data['token'], 'SSL');
+        $data['online'] = $this->url->link('report/customer_online', 'token=' . $this->session->data['token'], 'SSL') . $suffix;
 
         return $this->load->view('dashboard/online.tpl', $data);
     }

--- a/admin/controller/dashboard/order.php
+++ b/admin/controller/dashboard/order.php
@@ -34,18 +34,22 @@ class ControllerDashboardOrder extends Controller {
         $order_total = $this->model_sale_order->getTotalOrders();
         
         if ($order_total > 1000000000000) {
-            $data['total'] = round($order_total / 1000000000000, 1) . 'T';
+            $data['total'] = round($order_total / 1000000000000, 1);
+            $suffix = $this->language->get('trillion_suffix');
         } elseif ($order_total > 1000000000) {
-            $data['total'] = round($order_total / 1000000000, 1) . 'B';
+            $data['total'] = round($order_total / 1000000000, 1);
+            $suffix = $this->language->get('billion_suffix');
         } elseif ($order_total > 1000000) {
-            $data['total'] = round($order_total / 1000000, 1) . 'M';
+            $data['total'] = round($order_total / 1000000, 1);
+            $suffix = $this->language->get('million_suffix');
         } elseif ($order_total > 1000) {
-            $data['total'] = round($order_total / 1000, 1) . 'K';                        
+            $data['total'] = round($order_total / 1000, 1);
+            $suffix = $this->language->get('thousand_suffix');
         } else {
             $data['total'] = $order_total;
         }
         
-        $data['order'] = $this->url->link('sale/order', 'token=' . $this->session->data['token'], 'SSL');
+        $data['order'] = $this->url->link('sale/order', 'token=' . $this->session->data['token'], 'SSL') . $suffix;
 
         return $this->load->view('dashboard/order.tpl', $data);
     }

--- a/admin/controller/dashboard/sale.php
+++ b/admin/controller/dashboard/sale.php
@@ -34,16 +34,16 @@ class ControllerDashboardSale extends Controller {
 
         if ($sale_total > 1000000000000) {
             $data['total'] = round($sale_total / 1000000000000, 1);
-            $suffix = 'T';
+            $suffix = $this->language->get('trillion_suffix');
         } elseif ($sale_total > 1000000000) {
             $data['total'] = round($sale_total / 1000000000, 1);
-            $suffix = 'B';
+            $suffix = $this->language->get('billion_suffix');
         } elseif ($sale_total > 1000000) {
             $data['total'] = round($sale_total / 1000000, 1);
-            $suffix = 'M';
+            $suffix = $this->language->get('million_suffix');
         } elseif ($sale_total > 1000) {
             $data['total'] = round($sale_total / 1000, 1);
-            $suffix = 'K';
+            $suffix = $this->language->get('thousand_suffix');
         } else {
             $data['total'] = round($sale_total);
             $suffix = '';

--- a/admin/language/en-GB/default.php
+++ b/admin/language/en-GB/default.php
@@ -15,6 +15,10 @@ $_['time_format']                   = 'h:i:s A';
 $_['datetime_format']               = 'd/m/Y H:i:s';
 $_['decimal_point']                 = '.';
 $_['thousand_point']                = ',';
+$_['thousand_suffix']               = 'K';
+$_['million_suffix']                = 'M';
+$_['billion_suffix']                = 'B';
+$_['trillion_suffix']               = 'T';
 
 // Text
 $_['text_yes']                      = 'Yes';


### PR DESCRIPTION
Add amount suffixes as language strings, so translators and store owners can decide what to use for each language, as they know best what suites their language/country.

It's for rounding of thousand, million, billion and trillion in narrowed views like in the admin dashboard widget where the full amount doesn't fit.
