### PR TITLE
Address format, postcode required - Svalbard and Jan Mayen

### DIFF
--- a/install/tables.sql
+++ b/install/tables.sql
@@ -585,7 +585,7 @@ INSERT INTO `ar_country` (`country_id`, `name`, `iso_code_2`, `iso_code_3`, `add
 (198, 'St. Pierre and Miquelon', 'PM', 'SPM', '', 0, 1),
 (199, 'Sudan', 'SD', 'SDN', '', 0, 1),
 (200, 'Suriname', 'SR', 'SUR', '', 0, 1),
-(201, 'Svalbard and Jan Mayen Islands', 'SJ', 'SJM', '', 0, 1),
+(201, 'Svalbard and Jan Mayen Islands', 'SJ', 'SJM', '{company}\r\n{firstname} {lastname}\r\n{address_1}\r\n{address_2}\r\n{postcode} {city}\r\n{country}', 1, 1),
 (202, 'Swaziland', 'SZ', 'SWZ', '', 0, 1),
 (203, 'Sweden', 'SE', 'SWE', '{company}\r\n{firstname} {lastname}\r\n{address_1}\r\n{address_2}\r\n{postcode} {city}\r\n{country}', 1, 1),
 (204, 'Switzerland', 'CH', 'CHE', '', 0, 1),


### PR DESCRIPTION
Address format and postcode required also for Svalbard and Jan Mayen Islands (previously forgotten)
