### PR TITLE
"Successfully" to be considered redundant...

### DIFF
--- a/catalog/language/en-GB/tool/upload.php
+++ b/catalog/language/en-GB/tool/upload.php
@@ -7,7 +7,7 @@
  */
 
 // Text
-$_['text_upload']    = 'Your file was successfully uploaded!';
+$_['text_upload']    = 'Your file was uploaded!';
 
 // Error
 $_['error_filename'] = 'Filename must be between 3 and 64 characters!';


### PR DESCRIPTION
This is not a "real" issue nor fix.
It's up to you to consider it or not to be merged.
The thing is that source languages are the base for quality t9n and that the use of "success" or "successfully" are nowadays considered as redundant in those kind of strings.
Here for example, if the file "was uploaded", this implies that it was "successfully" or "with success".
