### PR TITLE
Adding description support for shipping modules

### DIFF
--- a/catalog/controller/checkout/shipping_method.php
+++ b/catalog/controller/checkout/shipping_method.php
@@ -48,6 +48,7 @@ class ControllerCheckoutShippingMethod extends Controller {
                     if ($quote) {
                         $method_data[$result['code']] = array(
                             'title'      => $quote['title'],
+                            'description'=> (isset($quote['description']) ? $quote['description'] : ''),
                             'quote'      => $quote['quote'],
                             'sort_order' => $quote['sort_order'],
                             'error'      => $quote['error']

--- a/catalog/view/theme/default/template/checkout/shipping_method.tpl
+++ b/catalog/view/theme/default/template/checkout/shipping_method.tpl
@@ -5,6 +5,9 @@
 <p><?php echo $text_shipping_method; ?></p>
 <?php foreach ($shipping_methods as $shipping_method) { ?>
 <p><strong><?php echo $shipping_method['title']; ?></strong></p>
+<?php if (isset($shipping_method['description']) && $shipping_method['description']) { ?>
+<p class="shipping_desc"><?php echo $shipping_method['description']; ?></p>
+<?php } ?>
 <?php if (!$shipping_method['error']) { ?>
 <?php foreach ($shipping_method['quote'] as $quote) { ?>
 <div class="radio">
@@ -15,7 +18,11 @@
         <?php } else { ?>
         <input type="radio" name="shipping_method" value="<?php echo $quote['code']; ?>" />
         <?php } ?>
-        <?php echo $quote['title']; ?> - <?php echo $quote['text']; ?></label>
+        <?php echo $quote['title']; ?> - <?php echo $quote['text']; ?>
+        <?php if (isset($quote['description']) && $quote['description']) { ?>
+        <br /><span class="shipping_desc"><?php echo $quote['description']; ?></span>
+        <?php } ?>
+    </label>
 </div>
 <?php } ?>
 <?php } else { ?>

--- a/catalog/view/theme/default/template/checkout/shipping_method.tpl
+++ b/catalog/view/theme/default/template/checkout/shipping_method.tpl
@@ -4,10 +4,11 @@
 <?php if ($shipping_methods) { ?>
 <p><?php echo $text_shipping_method; ?></p>
 <?php foreach ($shipping_methods as $shipping_method) { ?>
-<p><strong><?php echo $shipping_method['title']; ?></strong></p>
+<p><strong><?php echo $shipping_method['title']; ?></strong>
 <?php if (isset($shipping_method['description']) && $shipping_method['description']) { ?>
-<p class="shipping_desc"><?php echo $shipping_method['description']; ?></p>
+<br /><span class="shipping-method-desc"><?php echo $shipping_method['description']; ?></span>
 <?php } ?>
+</p>
 <?php if (!$shipping_method['error']) { ?>
 <?php foreach ($shipping_method['quote'] as $quote) { ?>
 <div class="radio">
@@ -20,7 +21,7 @@
         <?php } ?>
         <?php echo $quote['title']; ?> - <?php echo $quote['text']; ?>
         <?php if (isset($quote['description']) && $quote['description']) { ?>
-        <br /><span class="shipping_desc"><?php echo $quote['description']; ?></span>
+        <br /><span class="shipping-quote-desc"><?php echo $quote['description']; ?></span>
         <?php } ?>
     </label>
 </div>

--- a/catalog/view/theme/second/template/checkout/shipping_method.tpl
+++ b/catalog/view/theme/second/template/checkout/shipping_method.tpl
@@ -5,6 +5,9 @@
 <p><?php echo $text_shipping_method; ?></p>
 <?php foreach ($shipping_methods as $shipping_method) { ?>
 <p><strong><?php echo $shipping_method['title']; ?></strong></p>
+<?php if (isset($shipping_method['description']) && $shipping_method['description']) { ?>
+<p class="shipping_desc"><?php echo $shipping_method['description']; ?></p>
+<?php } ?>
 <?php if (!$shipping_method['error']) { ?>
 <?php foreach ($shipping_method['quote'] as $quote) { ?>
 <div class="radio">
@@ -15,7 +18,11 @@
         <?php } else { ?>
         <input type="radio" name="shipping_method" value="<?php echo $quote['code']; ?>" />
         <?php } ?>
-        <?php echo $quote['title']; ?> - <?php echo $quote['text']; ?></label>
+        <?php echo $quote['title']; ?> - <?php echo $quote['text']; ?>
+        <?php if (isset($quote['description']) && $quote['description']) { ?>
+        <br /><span class="shipping_desc"><?php echo $quote['description']; ?></span>
+        <?php } ?>
+    </label>
 </div>
 <?php } ?>
 <?php } else { ?>

--- a/catalog/view/theme/second/template/checkout/shipping_method.tpl
+++ b/catalog/view/theme/second/template/checkout/shipping_method.tpl
@@ -4,10 +4,11 @@
 <?php if ($shipping_methods) { ?>
 <p><?php echo $text_shipping_method; ?></p>
 <?php foreach ($shipping_methods as $shipping_method) { ?>
-<p><strong><?php echo $shipping_method['title']; ?></strong></p>
+<p><strong><?php echo $shipping_method['title']; ?></strong>
 <?php if (isset($shipping_method['description']) && $shipping_method['description']) { ?>
-<p class="shipping_desc"><?php echo $shipping_method['description']; ?></p>
+<br /><span class="shipping-method-desc"><?php echo $shipping_method['description']; ?></span>
 <?php } ?>
+</p>
 <?php if (!$shipping_method['error']) { ?>
 <?php foreach ($shipping_method['quote'] as $quote) { ?>
 <div class="radio">
@@ -20,7 +21,7 @@
         <?php } ?>
         <?php echo $quote['title']; ?> - <?php echo $quote['text']; ?>
         <?php if (isset($quote['description']) && $quote['description']) { ?>
-        <br /><span class="shipping_desc"><?php echo $quote['description']; ?></span>
+        <br /><span class="shipping-quote-desc"><?php echo $quote['description']; ?></span>
         <?php } ?>
     </label>
 </div>


### PR DESCRIPTION
When developing a shipping module I realised there is need for a description field, as we have some info we want to display only on shipping selection, but not on order details and invoice etc.

I could of course make it a modification in the shipping module, but as I think it's useful for other shipping modules too, I prefer making it at PR for the core.

![shipping_description](https://cloud.githubusercontent.com/assets/858132/17465063/9397a536-5cf5-11e6-9dfa-e2a698e25d29.png)

![orderinfo_shipping](https://cloud.githubusercontent.com/assets/858132/17464647/9c167c2c-5cec-11e6-9426-5d0badaf211b.png)
