### PR TITLE
New sales report filter for payment method

### DIFF
--- a/admin/controller/report/sale_order.php
+++ b/admin/controller/report/sale_order.php
@@ -36,6 +36,12 @@ class ControllerReportSaleOrder extends Controller {
             $filter_order_status_id = 0;
         }
 
+        if (isset($this->request->get['filter_payment_code'])) {
+            $filter_payment_code = $this->request->get['filter_payment_code'];
+        } else {
+            $filter_payment_code = '';
+        }
+
         if (isset($this->request->get['page'])) {
             $page = $this->request->get['page'];
         } else {
@@ -60,6 +66,10 @@ class ControllerReportSaleOrder extends Controller {
             $url .= '&filter_order_status_id=' . $this->request->get['filter_order_status_id'];
         }
 
+        if (isset($this->request->get['filter_payment_code'])) {
+            $url .= '&filter_payment_code=' . $this->request->get['filter_payment_code'];
+        }
+
         if (isset($this->request->get['page'])) {
             $url .= '&page=' . $this->request->get['page'];
         }
@@ -81,10 +91,11 @@ class ControllerReportSaleOrder extends Controller {
         $data['orders'] = array();
 
         $filter_data = array(
-            'filter_date_start'         => $filter_date_start,
-            'filter_date_end'         => $filter_date_end,
+            'filter_date_start'      => $filter_date_start,
+            'filter_date_end'        => $filter_date_end,
             'filter_group'           => $filter_group,
             'filter_order_status_id' => $filter_order_status_id,
+            'filter_payment_code'    => $filter_payment_code,
             'start'                  => ($page - 1) * $this->config->get('config_limit_admin'),
             'limit'                  => $this->config->get('config_limit_admin')
         );
@@ -110,6 +121,7 @@ class ControllerReportSaleOrder extends Controller {
         $data['text_no_results'] = $this->language->get('text_no_results');
         $data['text_confirm'] = $this->language->get('text_confirm');
         $data['text_all_status'] = $this->language->get('text_all_status');
+        $data['text_all_payment'] = $this->language->get('text_all_payment');
 
         $data['column_date_start'] = $this->language->get('column_date_start');
         $data['column_date_end'] = $this->language->get('column_date_end');
@@ -122,16 +134,21 @@ class ControllerReportSaleOrder extends Controller {
         $data['entry_date_end'] = $this->language->get('entry_date_end');
         $data['entry_group'] = $this->language->get('entry_group');
         $data['entry_status'] = $this->language->get('entry_status');
+        $data['entry_payment'] = $this->language->get('entry_payment');
 
         $data['button_filter'] = $this->language->get('button_filter');
         $data['button_show_filter'] = $this->language->get('button_show_filter');
-        $data['button_hide_filter'] = $this->language->get('button_hide_filter');        
+        $data['button_hide_filter'] = $this->language->get('button_hide_filter');
 
         $data['token'] = $this->session->data['token'];
 
         $this->load->model('localisation/order_status');
 
         $data['order_statuses'] = $this->model_localisation_order_status->getOrderStatuses();
+
+        $this->load->model('extension/extension');
+
+        $data['payment_methods'] = $this->model_extension_extension->getExtensions(array('filter_type' => 'payment'));
 
         $data['groups'] = array();
 
@@ -173,6 +190,10 @@ class ControllerReportSaleOrder extends Controller {
             $url .= '&filter_order_status_id=' . $this->request->get['filter_order_status_id'];
         }
 
+        if (isset($this->request->get['filter_payment_code'])) {
+            $url .= '&filter_payment_code=' . $this->request->get['filter_payment_code'];
+        }
+
         $pagination = new Pagination();
         $pagination->total = $order_total;
         $pagination->page = $page;
@@ -187,6 +208,7 @@ class ControllerReportSaleOrder extends Controller {
         $data['filter_date_end'] = $filter_date_end;
         $data['filter_group'] = $filter_group;
         $data['filter_order_status_id'] = $filter_order_status_id;
+        $data['filter_payment_code'] = $filter_payment_code;
 
         $data['header'] = $this->load->controller('common/header');
         $data['column_left'] = $this->load->controller('common/column_left');

--- a/admin/controller/report/sale_order.php
+++ b/admin/controller/report/sale_order.php
@@ -148,7 +148,18 @@ class ControllerReportSaleOrder extends Controller {
 
         $this->load->model('extension/extension');
 
-        $data['payment_methods'] = $this->model_extension_extension->getExtensions(array('filter_type' => 'payment'));
+        $payment_methods = $this->model_extension_extension->getExtensions(array('filter_type' => 'payment'));
+
+        $data['payment_methods'] = array();
+
+        foreach ($payment_methods as $payment_method) {
+            $this->load->language('payment/' . $payment_method['code']);
+
+            $data['payment_methods'][] = array(
+                'code'  => $payment_method['code'],
+                'title' => $this->language->get('heading_title'),
+            );
+        }
 
         $data['groups'] = array();
 

--- a/admin/language/en-GB/report/sale_order.php
+++ b/admin/language/en-GB/report/sale_order.php
@@ -31,4 +31,4 @@ $_['entry_date_start']  = 'Date Start';
 $_['entry_date_end']    = 'Date End';
 $_['entry_group']       = 'Group By';
 $_['entry_status']      = 'Order Status';
-$_['entry_payment']     = 'Payment Method Code';
+$_['entry_payment']     = 'Payment Method';

--- a/admin/language/en-GB/report/sale_order.php
+++ b/admin/language/en-GB/report/sale_order.php
@@ -16,6 +16,7 @@ $_['text_month']        = 'Months';
 $_['text_week']         = 'Weeks';
 $_['text_day']          = 'Days';
 $_['text_all_status']   = 'All Statuses';
+$_['text_all_payment']  = 'All Payment Methods';
 
 // Column
 $_['column_date_start'] = 'Date Start';
@@ -30,3 +31,4 @@ $_['entry_date_start']  = 'Date Start';
 $_['entry_date_end']    = 'Date End';
 $_['entry_group']       = 'Group By';
 $_['entry_status']      = 'Order Status';
+$_['entry_payment']     = 'Payment Method Code';

--- a/admin/model/report/sale.php
+++ b/admin/model/report/sale.php
@@ -155,6 +155,10 @@ class ModelReportSale extends Model {
             $sql .= " WHERE o.order_status_id > '0'";
         }
 
+        if (!empty($data['filter_payment_code'])) {
+            $sql .= " AND o.payment_code = '" . $data['filter_payment_code'] . "'";
+        }
+
         if (!empty($data['filter_date_start'])) {
             $sql .= " AND DATE(o.date_added) >= '" . $this->db->escape($data['filter_date_start']) . "'";
         }
@@ -231,6 +235,10 @@ class ModelReportSale extends Model {
             $sql .= " WHERE order_status_id = '" . (int)$data['filter_order_status_id'] . "'";
         } else {
             $sql .= " WHERE order_status_id > '0'";
+        }
+
+        if (!empty($data['filter_payment_code'])) {
+            $sql .= " AND payment_code = '" . $data['filter_payment_code'] . "'";
         }
 
         if (!empty($data['filter_date_start'])) {

--- a/admin/view/template/report/sale_order.tpl
+++ b/admin/view/template/report/sale_order.tpl
@@ -66,6 +66,19 @@
                                     <?php } ?>
                                 </select>
                             </div>
+                            <div class="form-group">
+                                <label class="control-label" for="input-payment"><?php echo $entry_payment; ?></label>
+                                <select name="filter_payment_code" id="input-payment" class="form-control">
+                                    <option value="0"><?php echo $text_all_payment; ?></option>
+                                    <?php foreach ($payment_methods as $payment_method) { ?>
+                                    <?php if ($payment_method['code'] == $filter_payment_code) { ?>
+                                    <option value="<?php echo $payment_method['code']; ?>" selected="selected"><?php echo $payment_method['code']; ?></option>
+                                    <?php } else { ?>
+                                    <option value="<?php echo $payment_method['code']; ?>"><?php echo $payment_method['code']; ?></option>
+                                    <?php } ?>
+                                    <?php } ?>
+                                </select>
+                            </div>
                             <button type="button" id="button-filter" class="btn btn-primary pull-right"><i class="fa fa-search"></i> <?php echo $button_filter; ?></button>
                         </div>
                     </div>
@@ -135,6 +148,12 @@
 
         if (filter_order_status_id != 0) {
             url += '&filter_order_status_id=' + encodeURIComponent(filter_order_status_id);
+        }
+
+        var filter_payment_code = $('select[name=\'filter_payment_code\']').val();
+
+        if (filter_payment_code) {
+            url += '&filter_payment_code=' + encodeURIComponent(filter_payment_code);
         }
 
         location = url;

--- a/admin/view/template/report/sale_order.tpl
+++ b/admin/view/template/report/sale_order.tpl
@@ -72,9 +72,9 @@
                                     <option value="0"><?php echo $text_all_payment; ?></option>
                                     <?php foreach ($payment_methods as $payment_method) { ?>
                                     <?php if ($payment_method['code'] == $filter_payment_code) { ?>
-                                    <option value="<?php echo $payment_method['code']; ?>" selected="selected"><?php echo $payment_method['code']; ?></option>
+                                    <option value="<?php echo $payment_method['code']; ?>" selected="selected"><?php echo $payment_method['title']; ?></option>
                                     <?php } else { ?>
-                                    <option value="<?php echo $payment_method['code']; ?>"><?php echo $payment_method['code']; ?></option>
+                                    <option value="<?php echo $payment_method['code']; ?>"><?php echo $payment_method['title']; ?></option>
                                     <?php } ?>
                                     <?php } ?>
                                 </select>

--- a/admin/view/theme/basic/template/report/sale_order.tpl
+++ b/admin/view/theme/basic/template/report/sale_order.tpl
@@ -65,9 +65,9 @@
                                     <option value="0"><?php echo $text_all_payment; ?></option>
                                     <?php foreach ($payment_methods as $payment_method) { ?>
                                     <?php if ($payment_method['code'] == $payment_method) { ?>
-                                    <option value="<?php echo $payment_method['code']; ?>" selected="selected"><?php echo $payment_method['code']; ?></option>
+                                    <option value="<?php echo $payment_method['code']; ?>" selected="selected"><?php echo $payment_method['title']; ?></option>
                                     <?php } else { ?>
-                                    <option value="<?php echo $payment_method['code']; ?>"><?php echo $payment_method['code']; ?></option>
+                                    <option value="<?php echo $payment_method['code']; ?>"><?php echo $payment_method['title']; ?></option>
                                     <?php } ?>
                                     <?php } ?>
                                 </select>
@@ -114,7 +114,7 @@
                                 <label class="filter-label"> 
                                 <?php foreach ($payment_methods as $payment_method) { ?>
                                 <?php if ($payment_method['code'] == $filter_payment_code) { ?>
-                                <?php echo $payment_method['code']; ?>
+                                <?php echo $payment_method['title']; ?>
                                 <?php } ?>
                                 <?php } ?>
                                 </label>

--- a/admin/view/theme/basic/template/report/sale_order.tpl
+++ b/admin/view/theme/basic/template/report/sale_order.tpl
@@ -29,6 +29,7 @@
                                         <li><a class="filter-list-type" onclick="changeFilterType('<?php echo $entry_date_end; ?>', 'filter_date_end');"><?php echo $entry_date_end; ?></a></li>
                                         <li><a class="filter-list-type" onclick="changeFilterType('<?php echo $entry_group; ?>', 'filter_group');"><?php echo $entry_group; ?></a></li>
                                         <li><a class="filter-list-type" onclick="changeFilterType('<?php echo $entry_status; ?>', 'filter_order_status_id');"><?php echo $entry_status; ?></a></li>
+                                        <li><a class="filter-list-type" onclick="changeFilterType('<?php echo $entry_status; ?>', 'filter_payment_code');"><?php echo $entry_payment; ?></a></li>
                                     </ul>
                                 </div>
                                 <div class="input-group date filter filter_date_start">
@@ -60,10 +61,20 @@
                                     <?php } ?>
                                     <?php } ?>
                                 </select>
+                                <select name="filter_payment_code" id="input-payment" class="form-control filter hidden">
+                                    <option value="0"><?php echo $text_all_payment; ?></option>
+                                    <?php foreach ($payment_methods as $payment_method) { ?>
+                                    <?php if ($payment_method['code'] == $payment_method) { ?>
+                                    <option value="<?php echo $payment_method['code']; ?>" selected="selected"><?php echo $payment_method['code']; ?></option>
+                                    <?php } else { ?>
+                                    <option value="<?php echo $payment_method['code']; ?>"><?php echo $payment_method['code']; ?></option>
+                                    <?php } ?>
+                                    <?php } ?>
+                                </select>
                             </div>
                         </div>
                     </div>
-                    <?php if (!empty($filter_date_start) || !empty($filter_date_end) || !empty($filter_group) || isset($filter_order_status_id)) { ?>
+                    <?php if (!empty($filter_date_start) || !empty($filter_date_end) || !empty($filter_group) || isset($filter_order_status_id) || isset($filter_payment_code)) { ?>
                     <div class="row">
                         <div class="col-lg-12 filter-tag">
                             <?php if ($filter_date_start) { ?>
@@ -95,6 +106,19 @@
                                 <?php } ?>
                                 </label>
                                 <a class="filter-remove" onclick="removeFilter(this, 'filter_order_status_id');"><i class="fa fa-times"></i></a>
+                            </div>
+                            <?php } ?>
+                            <?php if ($filter_payment_code) { ?>
+                            <div class="filter-info pull-left">
+                                <label class="control-label"><?php echo $entry_payment; ?>:</label> 
+                                <label class="filter-label"> 
+                                <?php foreach ($payment_methods as $payment_method) { ?>
+                                <?php if ($payment_method['code'] == $filter_payment_code) { ?>
+                                <?php echo $payment_method['code']; ?>
+                                <?php } ?>
+                                <?php } ?>
+                                </label>
+                                <a class="filter-remove" onclick="removeFilter(this, 'filter_payment_code');"><i class="fa fa-times"></i></a>
                             </div>
                             <?php } ?>
                         </div>
@@ -166,6 +190,12 @@
 
         if (filter_order_status_id != 0) {
             url += '&filter_order_status_id=' + encodeURIComponent(filter_order_status_id);
+        }
+
+        var filter_payment_code = $('select[name=\'filter_payment_code\']').val();
+
+        if (filter_payment_code != 0) {
+            url += '&filter_payment_code=' + encodeURIComponent(filter_payment_code);
         }
 
         location = url;


### PR DESCRIPTION
This adds a new filter to the sales report, allowing to filter the display to payment method.
It's t.ex great to have to check fees and commissions from payment providers. And also to see which one is worth having / paying for, and not. Etc.

Basic Mode:
![sales_report_payment_filter](https://cloud.githubusercontent.com/assets/858132/19992540/7decd23c-a247-11e6-9368-deeab3ab51c9.png)

Advanced Mode:
![sales_report_payment_filter_advanced](https://cloud.githubusercontent.com/assets/858132/19992552/8d558ae8-a247-11e6-9e9c-826d0f469590.png)