### PR TITLE
Checkout - Remember firstname and lastname

### DIFF
--- a/catalog/controller/checkout/address.php
+++ b/catalog/controller/checkout/address.php
@@ -369,12 +369,16 @@ class ControllerCheckoutAddress extends Controller
 
         if (isset($this->session->data['payment_address']['firstname'])) {
             $data['payment_firstname'] = $this->session->data['payment_address']['firstname'];
+        } else if (isset($this->session->data['guest']['firstname'])) {
+            $data['payment_firstname'] = $this->session->data['guest']['firstname'];
         } else {
             $data['payment_firstname'] = '';
         }
 
         if (isset($this->session->data['payment_address']['lastname'])) {
             $data['payment_lastname'] = $this->session->data['payment_address']['lastname'];
+        } else if (isset($this->session->data['guest']['lastname'])) {
+            $data['payment_lastname'] = $this->session->data['guest']['lastname'];
         } else {
             $data['payment_lastname'] = '';
         }

--- a/catalog/controller/checkout/address.php
+++ b/catalog/controller/checkout/address.php
@@ -369,6 +369,8 @@ class ControllerCheckoutAddress extends Controller
 
         if (isset($this->session->data['payment_address']['firstname'])) {
             $data['payment_firstname'] = $this->session->data['payment_address']['firstname'];
+        } else if (isset($this->session->data['customer_id'])) {
+            $data['payment_firstname'] = $this->customer->getFirstName();
         } else if (isset($this->session->data['guest']['firstname'])) {
             $data['payment_firstname'] = $this->session->data['guest']['firstname'];
         } else {
@@ -377,6 +379,8 @@ class ControllerCheckoutAddress extends Controller
 
         if (isset($this->session->data['payment_address']['lastname'])) {
             $data['payment_lastname'] = $this->session->data['payment_address']['lastname'];
+        } else if (isset($this->session->data['customer_id'])) {
+            $data['payment_lastname'] = $this->customer->getLastName();
         } else if (isset($this->session->data['guest']['lastname'])) {
             $data['payment_lastname'] = $this->session->data['guest']['lastname'];
         } else {


### PR DESCRIPTION
Remember firstname and lastname from Register/Guest (first step) to Address step in checkout.

Some has complaint about having to type their name twice in checkout, this would solve it. If it's the best way, I'm not sure, but it was the best I got working. ;)