### PR TITLE
Note about clearing cache on Update success & Backup restore

### DIFF
--- a/admin/language/en-GB/common/update.php
+++ b/admin/language/en-GB/common/update.php
@@ -30,7 +30,7 @@ $_['text_translation']                      = 'Translations';
 $_['text_check_error']                      = 'Version checker was not able to get new versions.';
 $_['text_check_success']                    = 'Version checker has been run successfully.';
 $_['text_update_error']                     = 'Update process has failed, please, try again.';
-$_['text_update_success']                   = 'Update process has been completed successfully.';
+$_['text_update_success']                   = 'Update process has been completed successfully.<br />Note! We recommend you clear the cache under "System -> Settings -> Cache" to ensure all is loaded correctly.';
 $_['text_up_to_date']                       = 'Congratulations! Your store is up to date.';
 $_['text_maintenance']                      = 'While your store is being updated, it will be in maintenance mode. As soon as the updates are complete, your store will return to normal.';
 

--- a/admin/language/en-GB/common/update.php
+++ b/admin/language/en-GB/common/update.php
@@ -30,7 +30,7 @@ $_['text_translation']                      = 'Translations';
 $_['text_check_error']                      = 'Version checker was not able to get new versions.';
 $_['text_check_success']                    = 'Version checker has been run successfully.';
 $_['text_update_error']                     = 'Update process has failed, please, try again.';
-$_['text_update_success']                   = 'Update process has been completed successfully.<br />Note! We recommend you clear the cache under "System -> Settings -> Cache" to ensure all is loaded correctly.';
+$_['text_update_success']                   = 'Update process has been completed successfully.<br />Note! We recommend you clear the cached content under "Tools -> Cache Manager" to ensure all is loaded correctly.';
 $_['text_up_to_date']                       = 'Congratulations! Your store is up to date.';
 $_['text_maintenance']                      = 'While your store is being updated, it will be in maintenance mode. As soon as the updates are complete, your store will return to normal.';
 

--- a/admin/language/en-GB/tool/backup.php
+++ b/admin/language/en-GB/tool/backup.php
@@ -11,7 +11,7 @@ $_['heading_title']    = 'Backup &amp; Restore';
 
 // Text
 $_['text_backup']      = 'Download Backup';
-$_['text_success']     = 'Success: You have successfully imported your database!<br />Note! We recommend you clear the cache under "System -> Settings -> Cache" to ensure all is loaded correctly.';
+$_['text_success']     = 'Success: You have successfully imported your database!<br />Note! We recommend you clear the cached content under "Tools -> Cache Manager" to ensure all is loaded correctly.';
 $_['text_list']        = 'Upload List';
 
 // Entry

--- a/admin/language/en-GB/tool/backup.php
+++ b/admin/language/en-GB/tool/backup.php
@@ -11,7 +11,7 @@ $_['heading_title']    = 'Backup &amp; Restore';
 
 // Text
 $_['text_backup']      = 'Download Backup';
-$_['text_success']     = 'Success: You have successfully imported your database!';
+$_['text_success']     = 'Success: You have successfully imported your database!<br />Note! We recommend you clear the cache under "System -> Settings -> Cache" to ensure all is loaded correctly.';
 $_['text_list']        = 'Upload List';
 
 // Entry


### PR DESCRIPTION
A reminder to clear the cache after update and backup restore, to ensure all is loaded correctly.