### PR TITLE
simplify utf8-to/from-unicode functions

### DIFF
--- a/system/helper/utf8.php
+++ b/system/helper/utf8.php
@@ -531,32 +531,39 @@ if (extension_loaded('mbstring')) {
 
     function utf8_to_unicode($string) {
         $unicode = array();
-
-        for ($i = 0; $i < strlen($string); $i++) {
+        
+        $strlen = strlen($string);
+            
+        for ($i = 0; $i < $strlen; $i++) {
             $chr = ord($string[$i]);
 
             if ($chr >= 0 && $chr <= 127) {
-                $unicode[] = (ord($string[$i]) * pow(64, 0));
+                $unicode[] = ($chr * pow(64, 0));
+                continue;
             }
 
             if ($chr >= 192 && $chr <= 223) {
-                $unicode[] = ((ord($string[$i]) - 192) * pow(64, 1) + (ord($string[$i + 1]) - 128) * pow(64, 0));
+                $unicode[] = (($chr - 192) * pow(64, 1) + (ord($string[$i + 1]) - 128) * pow(64, 0));
+                continue;
             }
 
             if ($chr >= 224 && $chr <= 239) {
-                $unicode[] = ((ord($string[$i]) - 224) * pow(64, 2) + (ord($string[$i + 1]) - 128) * pow(64, 1) + (ord($string[$i + 2]) - 128) * pow(64, 0));
+                $unicode[] = (($chr - 224) * pow(64, 2) + (ord($string[$i + 1]) - 128) * pow(64, 1) + (ord($string[$i + 2]) - 128) * pow(64, 0));
+                continue;
             }
 
             if ($chr >= 240 && $chr <= 247) {
-                $unicode[] = ((ord($string[$i]) - 240) * pow(64, 3) + (ord($string[$i + 1]) - 128) * pow(64, 2) + (ord($string[$i + 2]) - 128) * pow(64, 1) + (ord($string[$i + 3]) - 128) * pow(64, 0));
+                $unicode[] = (($chr - 240) * pow(64, 3) + (ord($string[$i + 1]) - 128) * pow(64, 2) + (ord($string[$i + 2]) - 128) * pow(64, 1) + (ord($string[$i + 3]) - 128) * pow(64, 0));
+                continue;
             }
 
             if ($chr >= 248 && $chr <= 251) {
-                $unicode[] = ((ord($string[$i]) - 248) * pow(64, 4) + (ord($string[$i + 1]) - 128) * pow(64, 3) + (ord($string[$i + 2]) - 128) * pow(64, 2) + (ord($string[$i + 3]) - 128) * pow(64, 1) + (ord($string[$i + 4]) - 128) * pow(64, 0));
+                $unicode[] = (($chr - 248) * pow(64, 4) + (ord($string[$i + 1]) - 128) * pow(64, 3) + (ord($string[$i + 2]) - 128) * pow(64, 2) + (ord($string[$i + 3]) - 128) * pow(64, 1) + (ord($string[$i + 4]) - 128) * pow(64, 0));
+                continue;
             }
 
             if ($chr == 252 && $chr == 253) {
-                $unicode[] = ((ord($string[$i]) - 252) * pow(64, 5) + (ord($string[$i + 1]) - 128) * pow(64, 4) + (ord($string[$i + 2]) - 128) * pow(64, 3) + (ord($string[$i + 3]) - 128) * pow(64, 2) + (ord($string[$i + 4]) - 128) * pow(64, 1) + (ord($string[$i + 5]) - 128) * pow(64, 0));
+                $unicode[] = (($chr - 252) * pow(64, 5) + (ord($string[$i + 1]) - 128) * pow(64, 4) + (ord($string[$i + 2]) - 128) * pow(64, 3) + (ord($string[$i + 3]) - 128) * pow(64, 2) + (ord($string[$i + 4]) - 128) * pow(64, 1) + (ord($string[$i + 5]) - 128) * pow(64, 0));
             }
         }
 
@@ -565,32 +572,40 @@ if (extension_loaded('mbstring')) {
 
     function unicode_to_utf8($unicode) {
         $string = '';
-
-        for ($i = 0; $i < count($unicode); $i++) {
-            if ($unicode[$i] < 128) {
-                $string .= chr($unicode[$i]);
+        
+        $count = count($unicode);
+        
+        for ($i = 0; $i < $count; $i++) {
+            $ord = $unicode[$i];
+            
+            if ($ord < 128) {
+                $string .= chr($ord);
+                continue;
             }
 
-            if ($unicode[$i] >= 128 && $unicode[$i] <= 2047) {
-                $string .= chr(($unicode[$i] / 64) + 192) . chr(($unicode[$i] % 64) + 128);
+            if ($ord >= 128 && $ord <= 2047) {
+                $string .= chr(($ord / 64) + 192) . chr(($ord % 64) + 128);
+                continue;
             }
 
-            if ($unicode[$i] >= 2048 && $unicode[$i] <= 65535) {
-                $string .= chr(($unicode[$i] / 4096) + 224) . chr(128 + (($unicode[$i] / 64) % 64)) . chr(($unicode[$i] % 64) + 128);
+            if ($ord >= 2048 && $ord <= 65535) {
+                $string .= chr(($ord / 4096) + 224) . chr(128 + (($ord / 64) % 64)) . chr(($ord % 64) + 128);
+                continue;
             }
 
-            if ($unicode[$i] >= 65536 && $unicode[$i] <= 2097151) {
-                $string .= chr(($unicode[$i] / 262144) + 240) . chr((($unicode[$i] / 4096) % 64) + 128) . chr((($unicode[$i] / 64) % 64) + 128) . chr(($unicode[$i] % 64) + 128);
+            if ($ord >= 65536 && $ord <= 2097151) {
+                $string .= chr(($ord / 262144) + 240) . chr((($ord / 4096) % 64) + 128) . chr((($ord / 64) % 64) + 128) . chr(($ord % 64) + 128);
+                continue;
             }
 
-            if ($unicode[$i] >= 2097152 && $unicode[$i] <= 67108863) {
-                $string  .= chr(($unicode[$i] / 16777216) + 248) . chr((($unicode[$i] / 262144) % 64) + 128) . chr((($unicode[$i] / 4096) % 64) + 128) . chr((($unicode[$i] / 64) % 64) + 128) . chr(($unicode[$i] % 64) + 128);
+            if ($ord >= 2097152 && $ord <= 67108863) {
+                $string  .= chr(($ord / 16777216) + 248) . chr((($ord / 262144) % 64) + 128) . chr((($ord / 4096) % 64) + 128) . chr((($ord / 64) % 64) + 128) . chr(($ord % 64) + 128);
+                continue;
             }
 
-            if ($unicode[$i] >= 67108864 && $unicode[$i] <= 2147483647) {
-                $string .= chr(($unicode[$i] / 1073741824) + 252) . chr((($unicode[$i] / 16777216) % 64) + 128) . chr((($unicode[$i] / 262144) % 64) + 128) . chr(128 + (($unicode[$i] / 4096) % 64)) . chr((($unicode[$i] / 64) % 64) + 128) . chr(($unicode[$i] % 64) + 128);
+            if ($ord >= 67108864 && $ord <= 2147483647) {
+                $string .= chr(($ord / 1073741824) + 252) . chr((($ord / 16777216) % 64) + 128) . chr((($ord / 262144) % 64) + 128) . chr(128 + (($ord / 4096) % 64)) . chr((($ord / 64) % 64) + 128) . chr(($ord % 64) + 128);
             }
-
         }
 
         return $string;

--- a/system/helper/utf8.php
+++ b/system/helper/utf8.php
@@ -535,35 +535,35 @@ if (extension_loaded('mbstring')) {
         $strlen = strlen($string);
             
         for ($i = 0; $i < $strlen; $i++) {
-            $chr = ord($string[$i]);
+            $ord = ord($string[$i]);
 
-            if ($chr >= 0 && $chr <= 127) {
-                $unicode[] = ($chr * pow(64, 0));
+            if ($ord >= 0 && $ord <= 127) {
+                $unicode[] = ($ord * pow(64, 0));
                 continue;
             }
 
-            if ($chr >= 192 && $chr <= 223) {
-                $unicode[] = (($chr - 192) * pow(64, 1) + (ord($string[$i + 1]) - 128) * pow(64, 0));
+            if ($ord >= 192 && $ord <= 223) {
+                $unicode[] = (($ord - 192) * pow(64, 1) + (ord($string[$i + 1]) - 128) * pow(64, 0));
                 continue;
             }
 
-            if ($chr >= 224 && $chr <= 239) {
-                $unicode[] = (($chr - 224) * pow(64, 2) + (ord($string[$i + 1]) - 128) * pow(64, 1) + (ord($string[$i + 2]) - 128) * pow(64, 0));
+            if ($ord >= 224 && $ord <= 239) {
+                $unicode[] = (($ord - 224) * pow(64, 2) + (ord($string[$i + 1]) - 128) * pow(64, 1) + (ord($string[$i + 2]) - 128) * pow(64, 0));
                 continue;
             }
 
-            if ($chr >= 240 && $chr <= 247) {
-                $unicode[] = (($chr - 240) * pow(64, 3) + (ord($string[$i + 1]) - 128) * pow(64, 2) + (ord($string[$i + 2]) - 128) * pow(64, 1) + (ord($string[$i + 3]) - 128) * pow(64, 0));
+            if ($ord >= 240 && $ord <= 247) {
+                $unicode[] = (($ord - 240) * pow(64, 3) + (ord($string[$i + 1]) - 128) * pow(64, 2) + (ord($string[$i + 2]) - 128) * pow(64, 1) + (ord($string[$i + 3]) - 128) * pow(64, 0));
                 continue;
             }
 
-            if ($chr >= 248 && $chr <= 251) {
-                $unicode[] = (($chr - 248) * pow(64, 4) + (ord($string[$i + 1]) - 128) * pow(64, 3) + (ord($string[$i + 2]) - 128) * pow(64, 2) + (ord($string[$i + 3]) - 128) * pow(64, 1) + (ord($string[$i + 4]) - 128) * pow(64, 0));
+            if ($ord >= 248 && $ord <= 251) {
+                $unicode[] = (($ord - 248) * pow(64, 4) + (ord($string[$i + 1]) - 128) * pow(64, 3) + (ord($string[$i + 2]) - 128) * pow(64, 2) + (ord($string[$i + 3]) - 128) * pow(64, 1) + (ord($string[$i + 4]) - 128) * pow(64, 0));
                 continue;
             }
 
-            if ($chr == 252 && $chr == 253) {
-                $unicode[] = (($chr - 252) * pow(64, 5) + (ord($string[$i + 1]) - 128) * pow(64, 4) + (ord($string[$i + 2]) - 128) * pow(64, 3) + (ord($string[$i + 3]) - 128) * pow(64, 2) + (ord($string[$i + 4]) - 128) * pow(64, 1) + (ord($string[$i + 5]) - 128) * pow(64, 0));
+            if ($ord == 252 && $ord == 253) {
+                $unicode[] = (($ord - 252) * pow(64, 5) + (ord($string[$i + 1]) - 128) * pow(64, 4) + (ord($string[$i + 2]) - 128) * pow(64, 3) + (ord($string[$i + 3]) - 128) * pow(64, 2) + (ord($string[$i + 4]) - 128) * pow(64, 1) + (ord($string[$i + 5]) - 128) * pow(64, 0));
             }
         }
 


### PR DESCRIPTION
- all conditions are mutually exclusive: we can use `continue` or `elseif`. `continue` makes code more readable to skip redundant checks.
- cache `strlen($string)` and `count($unicode)` results avoiding recalculation for every loop.
- avoid too many array access calls by using a cached variable (`$char` and `$ord = $unicode[$i];`).