### PR TITLE
Cache Manager - Fixing language bug on delete all button

### DIFF
--- a/admin/language/en-GB/tool/cache.php
+++ b/admin/language/en-GB/tool/cache.php
@@ -22,7 +22,8 @@ $_['column_files']              = 'Files';
 $_['column_size']               = 'Size';
 
 // Button
-$_['button_deleteall']          = 'Group';
+$_['button_delete']             = 'Delete Selected';
+$_['button_deleteall']          = 'Delete All';
 
 // Error
 $_['error_permission']          = 'Warning: You do not have permission to modify caches!';


### PR DESCRIPTION
Changing "Group" to "Delete All" for "button_deleteall"
Adding override for "button_delete" to display "Delete Selected", just to clarify the differences on the buttons.