### PR TITLE
Idea 40 - Email templates, Order statuses etc. - Language support on …

### DIFF
--- a/admin/model/localisation/language.php
+++ b/admin/model/localisation/language.php
@@ -263,6 +263,37 @@ class ModelLocalisationLanguage extends Model {
 
         $this->cache->delete('email_template');
 
+        if (file_exists(DIR_ADMIN . 'language/'. $this->db->escape($data['directory']) .'/update.sql')) {
+            $file = DIR_ADMIN . 'language/'. $this->db->escape($data['directory']) .'/update.sql';
+
+            $lines = file($file);
+
+            if (!empty($lines)) {
+                $sql = '';
+
+                foreach ($lines as $line) {
+                    if (!$line || (substr($line, 0, 2) == '--') || (substr($line, 0, 1) == '#')) {
+                        continue;
+                    }
+
+                    $line = str_replace("%language_id%", (int)$language_id, $line);
+
+                    $sql .= $line;
+
+                    if (!preg_match('/;\s*$/', $line)) {
+                        continue;
+                    }
+
+                    $sql = str_replace("INSERT INTO `ar_", "INSERT INTO `" . DB_PREFIX, $sql);
+                    $sql = str_replace("UPDATE `ar_", "UPDATE `" . DB_PREFIX, $sql);
+
+                    $this->db->query($sql);
+
+                    $sql = '';
+                }
+            }
+        }
+
         $this->trigger->fire('post.admin.language.add', array(&$language_id));
 
         return $language_id;

--- a/install/model/setting.php
+++ b/install/model/setting.php
@@ -156,6 +156,37 @@ class ModelSetting extends Model
         $db->query("INSERT INTO `" . DB_PREFIX . "setting` SET `code` = 'config', `key` = 'config_language', value = '" . $db->escape($lang_code) . "'");
         $db->query("INSERT INTO `" . DB_PREFIX . "setting` SET `code` = 'config', `key` = 'config_admin_language', value = '" . $db->escape($lang_code) . "'");
 
+        if (file_exists(DIR_ADMIN . 'language/'.$lang_directory.'/update.sql')) {
+            $file = DIR_ADMIN . 'language/'.$lang_directory.'/update.sql';
+
+            $lines = file($file);
+
+            if (!empty($lines)) {
+                $sql = '';
+
+                foreach ($lines as $line) {
+                    if (!$line || (substr($line, 0, 2) == '--') || (substr($line, 0, 1) == '#')) {
+                        continue;
+                    }
+
+                    $line = str_replace("%language_id%", 1, $line);
+
+                    $sql .= $line;
+
+                    if (!preg_match('/;\s*$/', $line)) {
+                        continue;
+                    }
+
+                    $sql = str_replace("INSERT INTO `ar_", "INSERT INTO `" . DB_PREFIX, $sql);
+                    $sql = str_replace("UPDATE `ar_", "UPDATE `" . DB_PREFIX, $sql);
+
+                    $db->query($sql);
+
+                    $sql = '';
+                }
+            }
+        }
+
         $addon_params['language_id'] = '1';
         $addon_params['theme_ids'] = array();
         $addon_params['extension_ids'] = array();


### PR DESCRIPTION
Hi!

I think this will be the final version, I managed to finished it :)

The rules are simple as I wanted to be and to do not overwrite to much core. On every language package from crowdin, in admin directory near default.php, a new file upload.sql will be added which will include the sql code to update the en-GB translation (which is copied automatically on new language install) on new Arastta install or on new added language from admin dashboard.

A sample update.sql file will look like this (ignore .txt extension - git rules):

[update.sql.txt](https://github.com/arastta/arastta/files/725094/update.sql.txt)
