### PR TITLE
Adding support for predefined colour schemes

### DIFF
--- a/admin/language/en-GB/appearance/customizer.php
+++ b/admin/language/en-GB/appearance/customizer.php
@@ -28,6 +28,7 @@ $_['text_general_sitename_label']               = 'Site Title';
 $_['text_general_font_label']                   = 'Site Font';
 $_['text_general_layout_label']                 = 'Layout';
 $_['text_colors_title']                         = 'Colours';
+$_['text_colors_colorscheme_label']             = 'Colour Scheme';
 $_['text_colors_container_background_label']    = 'Background Colour';
 $_['text_colors_container_color_label']         = 'Text Colour';
 $_['text_images_title']                         = 'Images';

--- a/admin/model/appearance/customizer.php
+++ b/admin/model/appearance/customizer.php
@@ -36,7 +36,7 @@ class ModelAppearanceCustomizer extends Model
                 }
             }
 
-            if ($key != 'save' && $key != 'sitename' && $key != 'font' && $key != 'custom-css' && $key != 'custom-js') {
+            if ($key != 'save' && $key != 'sitename' && $key != 'font' && $key != 'custom-css' && $key != 'custom-js' && $key != 'colorscheme') {
                 $item = $this->getCustomizerItem($key);
 
                 if ($key == 'layout_width' || $key == 'container_background-color' || $key == 'container-color_color' || $key == 'container_background-image') {


### PR DESCRIPTION
This minor change will prevent a colorscheme setting to be written to customizer.css

Some more info about the thoughts behind this in the forum: 
https://arastta.org/forum/customizer-predefined-color-schemes
https://arastta.org/forum/customizer-select-option-colour-scheme

To test, use t.ex. this in customizer.json:
```
    "colors": {
        "title": "text_colors_title",
        "description": "text_colors_description",
        "control": {
            "container_background-color": {
                    "type": "color",
                    "label": "text_colors_container_background_label",
                    "default": "#bdc3c7",
                    "selector": "body"
            },
            "container-color_color": {
                    "type": "color",
                    "label": "text_colors_container_color_label",
                    "default": "#666666",
                    "selector": "body"
            },
            "colorscheme": {
                "type": "select",
                "label": "text_colors_colorscheme_label",
                "default": "blue",
                "choices": {
                    "blue": "Blue",
                    "green": "Green",
                    "purple": "Purple",
                    "red": "Red"
                },
                "selector": "colors"
            }
        }
    }
```