### PR TITLE
Fixing #737 - Redirect to theme overview on close/cancel in Customizer

### DIFF
--- a/admin/controller/appearance/customizer.php
+++ b/admin/controller/appearance/customizer.php
@@ -113,6 +113,8 @@ class ControllerAppearanceCustomizer extends Controller
             $data['templates'][] = basename($directory);
         }
 
+        $data['cancel'] = $this->url->link('appearance/theme', 'token=' . $this->session->data['token'] . $url, 'SSL');
+
         $data['token'] = $this->session->data['token'];
 
         $this->response->setOutput($this->load->view('appearance/customizer.tpl', $data));

--- a/admin/view/template/appearance/customizer.tpl
+++ b/admin/view/template/appearance/customizer.tpl
@@ -47,7 +47,7 @@
             <div class="checkbox advance">
                 <label><input type="checkbox" id="advance-control" value=""><span><?php echo $text_advance; ?></span></label>
             </div>
-            <a class="customizer-controls-close" href="<?php echo $button_back;?>">
+            <a class="customizer-controls-close" href="<?php echo $cancel;?>">
                 <span class="screen-reader-text"><?php echo $entry_close; ?></span>
             </a>
             <span class="control-panel-back" tabindex="-1">


### PR DESCRIPTION
A simple fix for redirecting to theme list/overview on close/cancel in Customizer, to avoid a URL loop, and make it possible to get out of Customizer.